### PR TITLE
Make MessageParser mIRC Compatible

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -8,7 +8,7 @@ const debug = debuglog('ircs:MessageParser');
 
 function MessageParser() {
   return combine(
-    split('\r\n'),
+    split('\n'),
     through.obj(parse)
   )
 


### PR DESCRIPTION
Not sure why, `\r\n` isnt the character pattern used by common irc clients. Everything seems to work after changing this.